### PR TITLE
`import` matching

### DIFF
--- a/packages/scanner/src/lib.rs
+++ b/packages/scanner/src/lib.rs
@@ -12,7 +12,14 @@ pub fn parse_js<'a>(js: &'a str) -> Vec<&'a str> {
                 ProgramPart::Decl(some_part) => {
                     pd = match_declaration(some_part, pd)
                 },
-                the_thing => println!("Not a program part: {:?}", the_thing),
+                ProgramPart::Stmt(some_part) => {
+                    if let Stmt::Expr(expr) = some_part {
+                        if let Expr::Call(call) = expr {
+                            pd = match_expr(call, pd)
+                        }
+                    }
+                },
+                _ => (),
             }
         }
     }
@@ -23,7 +30,7 @@ fn match_declaration<'a>(declaration: Decl<'a>, mut pd: Vec<&'a str>) -> Vec<&'a
     match declaration {
         Decl::Import(import) => pd = match_import(import, pd),
         Decl::Variable(_, variable_vec) => pd = match_variable(variable_vec, pd),
-        the_thing => println!("log_declaration: {:?}", the_thing),
+        _ => (),
     }
     pd
 }
@@ -45,7 +52,7 @@ fn match_variable<'a>(
         if let Some(variable_init) = v.init {
             match variable_init {
                 Expr::Call(call) => pd = match_expr(call, pd),
-                the_thing => println!("log_require: {:?}", the_thing),
+                _ => (),
             }
         }
     }
@@ -54,10 +61,8 @@ fn match_variable<'a>(
 
 fn match_expr<'a>(expression: expr::CallExpr<'a>, mut pd: Vec<&'a str>,) -> Vec<&'a str> {
     if let Expr::Ident(callee) = *expression.callee {
-        println!("callee: {:?}", callee);
-        if callee == "require" || callee == "import" {
+        if callee == "require" {
             if let Some(argument) = expression.arguments.get(0) {
-                println!("{:?}", argument);
                 if let expr::Expr::Literal(literal) = argument {
                     if let expr::Literal::String(string_arg) = literal {
                         let quotes: &[_] = &['\'', '\"'];
@@ -81,6 +86,11 @@ mod tests {
     #[test]
     fn top_level_require_double_quotes() {
         let js = "const _ = require(\"lodash\");";
+        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+    }
+    #[test]
+    fn top_level_require_statement() {
+        let js = "require(\"lodash\");";
         assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
     }
     #[test]

--- a/packages/scanner/src/lib.rs
+++ b/packages/scanner/src/lib.rs
@@ -11,7 +11,16 @@ pub fn parse_js<'a>(js: &'a str) -> Vec<&'a str> {
             match the_part {
                 ProgramPart::Decl(some_part) => {
                     pd = match_declaration(some_part, pd)
-                }
+                },
+
+                // Dynamic imports
+                ProgramPart::Stmt(some_part) => {
+                    if let Stmt::Expr(expr) = some_part {
+                        if let Expr::Call(call) = expr {
+                            pd = match_expr(call, pd)
+                        }
+                    }
+                },
                 the_thing => println!("Not a program part: {:?}", the_thing),
             }
         }
@@ -21,9 +30,18 @@ pub fn parse_js<'a>(js: &'a str) -> Vec<&'a str> {
 
 fn match_declaration<'a>(declaration: Decl<'a>, mut pd: Vec<&'a str>) -> Vec<&'a str> {
     match declaration {
-        Decl::Import(import) => println!("{:?}", import),
+        Decl::Import(import) => pd = match_import(import, pd),
         Decl::Variable(_, variable_vec) => pd = match_variable(variable_vec, pd),
         the_thing => println!("log_declaration: {:?}", the_thing),
+    }
+    pd
+}
+
+fn match_import<'a>(import: Box<decl::ModImport<'a>>, mut pd: Vec<&'a str>) -> Vec<&'a str> {
+    let source = import.source;
+    if let expr::Literal::String(string_arg) = source {
+        let quotes: &[_] = &['\'', '\"'];
+        pd.push(string_arg.trim_matches(quotes));
     }
     pd
 }
@@ -43,12 +61,10 @@ fn match_variable<'a>(
     pd
 }
 
-fn match_expr<'a>(
-    expression: resast::ref_tree::expr::CallExpr<'a>,
-    mut pd: Vec<&'a str>,
-) -> Vec<&'a str> {
+fn match_expr<'a>(expression: expr::CallExpr<'a>, mut pd: Vec<&'a str>,) -> Vec<&'a str> {
     if let Expr::Ident(callee) = *expression.callee {
-        if callee == "require" {
+        println!("callee: {:?}", callee);
+        if callee == "require" || callee == "import" {
             if let Some(argument) = expression.arguments.get(0) {
                 println!("{:?}", argument);
                 if let expr::Expr::Literal(literal) = argument {
@@ -74,6 +90,26 @@ mod tests {
     #[test]
     fn top_level_require_double_quotes() {
         let js = "const _ = require(\"lodash\");";
+        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+    }
+    #[test]
+    fn top_level_default_import() {
+        let js = "import _ from 'lodash';";
+        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+    }
+    #[test]
+    fn top_level_import_alias() {
+        let js = "import * as lodash from \"lodash\";";
+        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+    }
+    #[test]
+    fn top_level_import_named() {
+        let js = "import { map } from \"lodash\";";
+        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+    }
+    #[test]
+    fn dynamic_import() {
+        let js = "import('lodash');";
         assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
     }
 }

--- a/packages/scanner/src/lib.rs
+++ b/packages/scanner/src/lib.rs
@@ -1,4 +1,5 @@
 use resast::ref_tree::prelude::*;
+use resast::ref_tree::{ProgramPart, decl, expr};
 use ressa::Parser;
 use std::vec::Vec;
 
@@ -8,14 +9,14 @@ pub fn parse_js<'a>(js: &'a str) -> Vec<&'a str> {
     for part in p {
         if let Ok(the_part) = part {
             match the_part {
-                resast::ref_tree::ProgramPart::Decl(some_part) => {
+                ProgramPart::Decl(some_part) => {
                     pd = match_declaration(some_part, pd)
                 }
                 the_thing => println!("Not a program part: {:?}", the_thing),
             }
         }
     }
-    return pd;
+    pd
 }
 
 fn match_declaration<'a>(declaration: Decl<'a>, mut pd: Vec<&'a str>) -> Vec<&'a str> {
@@ -28,7 +29,7 @@ fn match_declaration<'a>(declaration: Decl<'a>, mut pd: Vec<&'a str>) -> Vec<&'a
 }
 
 fn match_variable<'a>(
-    variable_vec: Vec<resast::ref_tree::decl::VariableDecl<'a>>,
+    variable_vec: Vec<decl::VariableDecl<'a>>,
     mut pd: Vec<&'a str>,
 ) -> Vec<&'a str> {
     for v in variable_vec {
@@ -50,8 +51,8 @@ fn match_expr<'a>(
         if callee == "require" {
             if let Some(argument) = expression.arguments.get(0) {
                 println!("{:?}", argument);
-                if let resast::ref_tree::expr::Expr::Literal(literal) = argument {
-                    if let resast::ref_tree::expr::Literal::String(string_arg) = literal {
+                if let expr::Expr::Literal(literal) = argument {
+                    if let expr::Literal::String(string_arg) = literal {
                         let quotes: &[_] = &['\'', '\"'];
                         pd.push(string_arg.trim_matches(quotes));
                     }

--- a/packages/scanner/src/lib.rs
+++ b/packages/scanner/src/lib.rs
@@ -60,8 +60,8 @@ fn match_variable<'a>(
 }
 
 fn match_expr<'a>(expression: expr::CallExpr<'a>, mut pd: Vec<&'a str>,) -> Vec<&'a str> {
-    if let Expr::Ident(callee) = *expression.callee {
-        if callee == "require" {
+    if let Expr::Ident(callee) = &*expression.callee {
+        if callee == &"require" {
             if let Some(argument) = expression.arguments.get(0) {
                 if let expr::Expr::Literal(literal) = argument {
                     if let expr::Literal::String(string_arg) = literal {

--- a/packages/scanner/src/lib.rs
+++ b/packages/scanner/src/lib.rs
@@ -3,8 +3,8 @@ use resast::ref_tree::{ProgramPart, decl, expr};
 use ressa::Parser;
 use std::vec::Vec;
 
-pub fn parse_js<'a>(js: &'a str) -> Vec<&'a str> {
-    let p = Parser::new(js).unwrap();
+pub fn parse_js<'a>(js: &'a str) -> Result<Vec<&'a str>, ressa::Error> {
+    let p = Parser::new(js)?;
     let mut pd = Vec::<&str>::new();
     for part in p {
         if let Ok(the_part) = part {
@@ -23,7 +23,7 @@ pub fn parse_js<'a>(js: &'a str) -> Vec<&'a str> {
             }
         }
     }
-    pd
+    Ok(pd)
 }
 
 fn match_declaration<'a>(declaration: Decl<'a>, mut pd: Vec<&'a str>) -> Vec<&'a str> {
@@ -81,31 +81,31 @@ mod tests {
     #[test]
     fn top_level_require_single_quotes() {
         let js = "const _ = require('lodash');";
-        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+        assert_eq!(&"lodash", parse_js(js).unwrap().get(0).unwrap())
     }
     #[test]
     fn top_level_require_double_quotes() {
         let js = "const _ = require(\"lodash\");";
-        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+        assert_eq!(&"lodash", parse_js(js).unwrap().get(0).unwrap())
     }
     #[test]
     fn top_level_require_statement() {
         let js = "require(\"lodash\");";
-        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+        assert_eq!(&"lodash", parse_js(js).unwrap().get(0).unwrap())
     }
     #[test]
     fn top_level_default_import() {
         let js = "import _ from 'lodash';";
-        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+        assert_eq!(&"lodash", parse_js(js).unwrap().get(0).unwrap())
     }
     #[test]
     fn top_level_import_alias() {
         let js = "import * as lodash from \"lodash\";";
-        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+        assert_eq!(&"lodash", parse_js(js).unwrap().get(0).unwrap())
     }
     #[test]
     fn top_level_import_named() {
         let js = "import { map } from \"lodash\";";
-        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
+        assert_eq!(&"lodash", parse_js(js).unwrap().get(0).unwrap())
     }
 }

--- a/packages/scanner/src/lib.rs
+++ b/packages/scanner/src/lib.rs
@@ -12,15 +12,6 @@ pub fn parse_js<'a>(js: &'a str) -> Vec<&'a str> {
                 ProgramPart::Decl(some_part) => {
                     pd = match_declaration(some_part, pd)
                 },
-
-                // Dynamic imports
-                ProgramPart::Stmt(some_part) => {
-                    if let Stmt::Expr(expr) = some_part {
-                        if let Expr::Call(call) = expr {
-                            pd = match_expr(call, pd)
-                        }
-                    }
-                },
                 the_thing => println!("Not a program part: {:?}", the_thing),
             }
         }
@@ -105,11 +96,6 @@ mod tests {
     #[test]
     fn top_level_import_named() {
         let js = "import { map } from \"lodash\";";
-        assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
-    }
-    #[test]
-    fn dynamic_import() {
-        let js = "import('lodash');";
         assert_eq!(&"lodash", parse_js(js).get(0).unwrap())
     }
 }


### PR DESCRIPTION
This matches on a variety of `import`s. Dynamic imports are matched as a statement and destructured into a `CallExpr` passed on into `match_expr`. 

Edit: rm'd dynamic imports and only focusing on static ones right now.